### PR TITLE
Add missing header stdexcept

### DIFF
--- a/src/libxdgbasedir/libxdgbasedir.cpp
+++ b/src/libxdgbasedir/libxdgbasedir.cpp
@@ -18,6 +18,7 @@
 #include "libxdgbasedir.h"
 #include "gettext_defs.h"
 #include <cstdlib>
+#include <stdexcept>
 
 namespace xdg
 {


### PR DESCRIPTION
On [line 88](https://github.com/emcrisostomo/libxdgbasedir/blob/48df831d1c1c83bc3cdb8e3b07af922864fb6515/src/libxdgbasedir/libxdgbasedir.cpp#L88) of `libxdgbasedir.cpp`, you use `std::runtime_error`. This needs the header `stdexcept`.